### PR TITLE
fix: preserve MIOT-REQUEST-MODEL when parsing and proxying Mijia passcode requests

### DIFF
--- a/src/app/api/passcode/route.ts
+++ b/src/app/api/passcode/route.ts
@@ -55,7 +55,6 @@ function appendHeaderIfPresent(headers: Headers, name: string, value: string): v
 function buildProxyHeaders(config: MijiaPasscodeRequestConfig, targetUrl: URL): Headers {
     const headers = new Headers({
         'domain-refer': targetUrl.host,
-        'MIOT-REQUEST-MODEL': 'xiaomi.gateway.hub1',
     });
 
     appendHeaderIfPresent(headers, 'Accept', config.accept);
@@ -66,6 +65,7 @@ function buildProxyHeaders(config: MijiaPasscodeRequestConfig, targetUrl: URL): 
     appendHeaderIfPresent(headers, 'operate-common', config.operateCommon);
     appendHeaderIfPresent(headers, 'Origin-From', config.originFrom);
     appendHeaderIfPresent(headers, 'X-XIAOMI-PROTOCAL-FLAG-CLI', config.xiaomiProtocolFlagCli);
+    appendHeaderIfPresent(headers, 'MIOT-REQUEST-MODEL', config.miotRequestModel);
 
     return headers;
 }

--- a/src/components/PasscodeCapturePanel.tsx
+++ b/src/components/PasscodeCapturePanel.tsx
@@ -362,12 +362,20 @@ export default function PasscodeCapturePanel({disabled, onInsert}: PasscodeCaptu
                                     onChange={event => updateConfig('originFrom', event.target.value)}
                                 />
                             </div>
-                            <Input
-                                size="small"
-                                placeholder="X-XIAOMI-PROTOCAL-FLAG-CLI"
-                                value={config.xiaomiProtocolFlagCli}
-                                onChange={event => updateConfig('xiaomiProtocolFlagCli', event.target.value)}
-                            />
+                            <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8}}>
+                                <Input
+                                    size="small"
+                                    placeholder="X-XIAOMI-PROTOCAL-FLAG-CLI"
+                                    value={config.xiaomiProtocolFlagCli}
+                                    onChange={event => updateConfig('xiaomiProtocolFlagCli', event.target.value)}
+                                />
+                                <Input
+                                    size="small"
+                                    placeholder="MIOT-REQUEST-MODEL"
+                                    value={config.miotRequestModel}
+                                    onChange={event => updateConfig('miotRequestModel', event.target.value)}
+                                />
+                            </div>
                             <Button
                                 size="small"
                                 type="primary"

--- a/src/lib/mijiaPasscode.ts
+++ b/src/lib/mijiaPasscode.ts
@@ -11,6 +11,7 @@ export interface MijiaPasscodeRequestConfig {
     operateCommon: string;
     originFrom: string;
     xiaomiProtocolFlagCli: string;
+    miotRequestModel: string;
 }
 
 export interface MijiaPasscodeParseResult {
@@ -41,6 +42,7 @@ export const defaultMijiaPasscodeRequestConfig: MijiaPasscodeRequestConfig = {
     operateCommon: '',
     originFrom: '',
     xiaomiProtocolFlagCli: '',
+    miotRequestModel: 'xiaomi.gateway.hub1',
 };
 
 const passcodeKeys = ['passcode', 'passwd', 'password', 'pwd'];
@@ -305,13 +307,19 @@ function parseCurlToConfig(text: string): MijiaPasscodeParseResult {
         operateCommon: readCurlHeader(request.headers, 'operate-common'),
         originFrom: readCurlHeader(request.headers, 'Origin-From'),
         xiaomiProtocolFlagCli: readCurlHeader(request.headers, 'X-XIAOMI-PROTOCAL-FLAG-CLI'),
+        miotRequestModel: readCurlHeader(request.headers, 'MIOT-REQUEST-MODEL') || defaultMijiaPasscodeRequestConfig.miotRequestModel,
     });
+    const found = isMijiaUrl(request.url) && Boolean(requestBody) && requestKind === 'passcode';
 
     return {
         config,
-        found: isMijiaUrl(request.url) && Boolean(requestBody) && (requestKind === 'passcode' || isRpc),
-        matchedRequestCount: 1,
-        message: '已从 CURL 文本中识别请求参数',
+        found,
+        matchedRequestCount: found ? 1 : 0,
+        message: found
+            ? '已从 CURL 文本中识别登录码请求参数'
+            : isRpc
+                ? '已从 CURL 文本中解析 RPC 请求，但未识别到登录码方法'
+                : '已从 CURL 文本中识别请求参数',
         source: 'curl',
     };
 }
@@ -356,14 +364,14 @@ export function parseMijiaPasscodeCaptureText(text: string): MijiaPasscodeParseR
         nextConfig.operateCommon = readHarHeader(request.headers, 'operate-common') || nextConfig.operateCommon;
         nextConfig.originFrom = readHarHeader(request.headers, 'Origin-From') || nextConfig.originFrom;
         nextConfig.xiaomiProtocolFlagCli = readHarHeader(request.headers, 'X-XIAOMI-PROTOCAL-FLAG-CLI') || nextConfig.xiaomiProtocolFlagCli;
+        nextConfig.miotRequestModel = readHarHeader(request.headers, 'MIOT-REQUEST-MODEL') || nextConfig.miotRequestModel;
 
         if (readString(request, 'method').toUpperCase() !== 'POST') continue;
         const postText = getHarPostText(request.postData);
         if (!postText) continue;
 
         const requestKind = detectRequestKind(postText);
-        const isRpc = url.includes('/app/home/rpc');
-        if (requestKind === 'passcode' || isRpc) {
+        if (requestKind === 'passcode') {
             foundPasscode = true;
             matchedRequestCount += 1;
             nextConfig.requestUrl = url;

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import {
+    findMijiaPasscodeValue,
+    parseMijiaPasscodeCaptureText,
+} from './lib/mijiaPasscode';
+
+const passcodeBody = 'data=' + encodeURIComponent(JSON.stringify({
+    method: 'miIO.get_central_link_passcode',
+    params: [],
+}));
+
+const har = {
+    log: {
+        entries: [
+            {
+                request: {
+                    method: 'POST',
+                    url: 'https://core.api.mijia.tech/app/home/rpc/123',
+                    headers: [
+                        {name: 'Cookie', value: 'serviceToken=token'},
+                        {name: 'MIOT-REQUEST-MODEL', value: 'xiaomi.gateway.hub2'},
+                    ],
+                    postData: {
+                        text: 'data=' + encodeURIComponent(JSON.stringify({
+                            method: 'miIO.get_autowebconfig_url',
+                            params: [],
+                        })),
+                    },
+                },
+            },
+            {
+                request: {
+                    method: 'POST',
+                    url: 'https://core.api.mijia.tech/app/home/rpc/456',
+                    headers: [
+                        {name: 'MIOT-REQUEST-MODEL', value: 'xiaomi.gateway.hub2'},
+                    ],
+                    postData: {text: passcodeBody},
+                },
+            },
+        ],
+    },
+};
+
+const parsedHar = parseMijiaPasscodeCaptureText(JSON.stringify(har));
+assert.equal(parsedHar.found, true);
+assert.equal(parsedHar.matchedRequestCount, 1);
+assert.equal(parsedHar.config.requestUrl, 'https://core.api.mijia.tech/app/home/rpc/456');
+assert.equal(parsedHar.config.passcodeRequestBody, passcodeBody);
+assert.equal(parsedHar.config.miotRequestModel, 'xiaomi.gateway.hub2');
+
+const curl = `curl 'https://core.api.mijia.tech/app/home/rpc/789' \\
+  -H 'MIOT-REQUEST-MODEL: xiaomi.gateway.hub3' \\
+  -H 'Cookie: serviceToken=token' \\
+  --data-raw '${passcodeBody}'`;
+const parsedCurl = parseMijiaPasscodeCaptureText(curl);
+assert.equal(parsedCurl.found, true);
+assert.equal(parsedCurl.matchedRequestCount, 1);
+assert.equal(parsedCurl.config.miotRequestModel, 'xiaomi.gateway.hub3');
+
+const nonPasscodeCurl = `curl 'https://core.api.mijia.tech/app/home/rpc/789' --data-raw 'data=${encodeURIComponent(JSON.stringify({method: 'miIO.get_autowebconfig_url'}))}'`;
+const parsedNonPasscodeCurl = parseMijiaPasscodeCaptureText(nonPasscodeCurl);
+assert.equal(parsedNonPasscodeCurl.found, false);
+assert.equal(parsedNonPasscodeCurl.matchedRequestCount, 0);
+
+assert.equal(findMijiaPasscodeValue({result: {passcode: '123456'}}), '123456');
+
+console.log('mijiaPasscode parser tests passed');


### PR DESCRIPTION
### Motivation
- Ensure the gateway model header used by Xiaomi central (MIOT-REQUEST-MODEL) is preserved from HAR/cURL captures instead of being hardcoded to `xiaomi.gateway.hub1` so passcode requests work for other hub models.
- Avoid false-positive passcode detection by treating only `miIO.get_central_link_passcode` as a login-code request and not generic RPCs like `miIO.get_autowebconfig_url`.
- Expose the gateway model in the manual passcode UI so users can correct or override it when needed.

### Description
- Added `miotRequestModel` to `MijiaPasscodeRequestConfig` with default `xiaomi.gateway.hub1` and updated parsing logic in `src/lib/mijiaPasscode.ts` to extract `MIOT-REQUEST-MODEL` from HAR and cURL inputs.
- Tightened passcode detection in `src/lib/mijiaPasscode.ts` so `found` is true only when the request body matches a passcode call (`miIO.get_central_link_passcode`) and non-passcode RPCs are not counted as matches.
- Updated proxy header building in `src/app/api/passcode/route.ts` to send the configured `MIOT-REQUEST-MODEL` header instead of using a hardcoded value.
- Added a `MIOT-REQUEST-MODEL` input to the manual parameters section in `src/components/PasscodeCapturePanel.tsx` so the model can be edited by users.
- Added `src/test.ts` with parser unit checks for HAR and cURL extraction and passcode detection to cover the new behavior.

### Testing
- Ran `npm run test` which executed `npx tsx src/test.ts` and the new parser tests passed.
- Ran type-checking with `npx tsc --noEmit` which succeeded with no errors.
- Ran lint via `npm run lint` (Next.js ESLint) which reported no warnings or errors.
- Built the app with `npm run build` and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3e4683c0832a9207262ad3fa7995)